### PR TITLE
feat: PrimitiveStridedArray to add `shape_strides` over PrimitiveArray

### DIFF
--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -32,9 +32,7 @@ function Base.iterate(layout::Content, state)
     end
 end
 
-function Base.size(layout::Content)
-    (length(layout),)
-end
+Base.size(layout::Content) = (length(layout),)
 
 ### PrimitiveArray #######################################################
 
@@ -42,25 +40,12 @@ struct PrimitiveArray{T,ARRAY<:AbstractArray{T,1}} <: Content
     data::ARRAY
 end
 
-function PrimitiveArray{T}() where {T}
-    PrimitiveArray(Vector{T}([]))
-end
+PrimitiveArray{T}() where {T} = PrimitiveArray(Vector{T}([]))
 
-function is_valid(layout::PrimitiveArray)
-    true
-end
-
-function Base.length(layout::PrimitiveArray)
-    length(layout.data)
-end
-
-function Base.firstindex(layout::PrimitiveArray)
-    firstindex(layout.data)
-end
-
-function Base.lastindex(layout::PrimitiveArray)
-    lastindex(layout.data)
-end
+is_valid(layout::PrimitiveArray) = true
+Base.length(layout::PrimitiveArray) = length(layout.data)
+Base.firstindex(layout::PrimitiveArray) = firstindex(layout.data)
+Base.lastindex(layout::PrimitiveArray) = lastindex(layout.data)
 
 function Base.getindex(layout::PrimitiveArray, i::Int)
     layout.data[i]
@@ -86,9 +71,8 @@ struct ListOffsetArray{INDEX<:IndexBig,CONTENT<:Content} <: Content
     content::CONTENT
 end
 
-function ListOffsetArray{INDEX,CONTENT}() where {INDEX<:IndexBig} where {CONTENT<:Content}
+ListOffsetArray{INDEX,CONTENT}() where {INDEX<:IndexBig} where {CONTENT<:Content} =
     AwkwardArray.ListOffsetArray(INDEX([0]), CONTENT())
-end
 
 function is_valid(layout::ListOffsetArray)
     if length(layout.offsets) < 1
@@ -105,17 +89,9 @@ function is_valid(layout::ListOffsetArray)
     return true
 end
 
-function Base.length(layout::ListOffsetArray)
-    length(layout.offsets) - 1
-end
-
-function Base.firstindex(layout::ListOffsetArray)
-    firstindex(layout.offsets)
-end
-
-function Base.lastindex(layout::ListOffsetArray)
-    lastindex(layout.offsets) - 1
-end
+Base.length(layout::ListOffsetArray) = length(layout.offsets) - 1
+Base.firstindex(layout::ListOffsetArray) = firstindex(layout.offsets)
+Base.lastindex(layout::ListOffsetArray) = lastindex(layout.offsets) - 1
 
 function Base.getindex(layout::ListOffsetArray, i::Int)
     start = layout.offsets[i] + firstindex(layout.content)

--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -64,62 +64,6 @@ function push!(layout::PrimitiveArray{T}, x::T) where {T}
     layout
 end
 
-### PrimitiveMultiArray ##################################################
-
-struct PrimitiveMultiArray{T,ARRAY<:AbstractArray{T,1}} <: Content
-    data::ARRAY
-    shape_strides::Vector{Tuple{Int64,Int64}}
-end
-
-PrimitiveMultiArray{T}(shape_strides::Vector{Tuple{Int64,Int64}}) where {T} =
-    PrimitiveMultiArray(Vector{T}([]), shape_strides)
-
-is_valid(layout::PrimitiveMultiArray) =
-    length(layout.shape_strides) >= 2 &&
-    layout.shape_strides[1][1] >= 0 &&
-    layout.shape_strides[1][2] >= 0 &&
-    layout.shape_strides[1][1] * layout.shape_strides[1][2] <= length(layout.data)
-# TODO: recurse into each lower number of dimensions.
-
-Base.length(layout::PrimitiveMultiArray) = layout.shape_strides[1][1]
-Base.firstindex(layout::PrimitiveMultiArray) = 1
-Base.lastindex(layout::PrimitiveMultiArray) = length(layout)
-
-function Base.getindex(layout::PrimitiveMultiArray, i::Int)
-    start = (i - 1) * layout.shape_strides[1][2] + firstindex(layout.data)
-    stop = i * layout.shape_strides[1][2] + firstindex(layout.data)
-    if length(layout.shape_strides) == 2
-        if layout.shape_strides[2][2] > 0
-            PrimitiveArray(layout.data[start:layout.shape_strides[2][2]:stop])
-        else
-            PrimitiveArray(layout.data[stop:layout.shape_strides[2][2]:start])
-        end
-    else
-        PrimitiveMultiArray(layout.data[start:stop], layout.shape_strides[2:end])
-    end
-end
-
-function Base.getindex(layout::PrimitiveMultiArray, r::UnitRange{Int})
-    start = (r.start - 1) * layout.shape_strides[1][2] + firstindex(layout.data)
-    stop = (r.stop - 1) * layout.shape_strides[1][2] + firstindex(layout.data)
-
-
-# This is getting nasty.
-
-
-
-    PrimitiveMultiArray(layout.data[r])
-end
-
-# function Base.:(==)(layout1::PrimitiveMultiArray, layout2::PrimitiveMultiArray)
-#     layout1.data == layout2.data
-# end
-
-# function push!(layout::PrimitiveMultiArray{T}, x::T) where {T}
-#     Base.push!(layout.data, x)
-#     layout
-# end
-
 ### ListOffsetArray ######################################################
 
 struct ListOffsetArray{INDEX<:IndexBig,CONTENT<:Content} <: Content


### PR DESCRIPTION
This is the conversion target for any NumPy arrays that aren't C-contiguous and 1-dimensional (to permit zero-copy conversions).

I'm sure Julia has these concepts, but `PrimitiveArray` had to be based on a strictly 1-dimensional `AbstractArray` to make the `Base.length` and `Base.size` functions usable internally. Ordinarily, `Base.length` means "the number of elements after flattening all dimensions" and `Base.size` refers to a rectilinear shape. Awkward operations need a `length` that behaves like Python's `len`: the length at a given level, opaque to what is included within.

PrimitiveStridedArray describes a multidimensional array in terms of a (NumPy-like) shape and strides, and it applies these concepts to a 1-dimensional buffer. By avoiding Julia's built-in concepts of `AbstractArray<T,N>` where `N` is the number of dimensions, it's no longer a breach of contract that the `length` of this thing does not count nested dimensions (i.e. behaves like Python's `len`).

The `shape_strides::Vector{Tuple{Int64,Int64}}` field takes precedence over `length(data)` (and ensuring that `data` is big enough is a validity check), and the "strides" are number of elements strides, not number of bytes, as it is in NumPy. (Awkward Array does not support [structured arrays](https://numpy.org/doc/stable/user/basics.rec.html).)