### PR TITLE
feat: implemented RecordArray (along with Record scalar).

### DIFF
--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -350,7 +350,27 @@ struct Record{ARRAY<:RecordArray}
     at::Int64
 end
 
-# FIXME: function copy
+function copy(
+    layout::RecordArray{CONTENTS,BEHAVIOR};
+    contents::Union{Unset,CONTENTS} = Unset(),
+    length::Union{Unset,Int64} = Unset(),
+    parameters::Union{Unset,Parameters} = Unset(),
+    behavior::Union{Unset,Symbol} = Unset(),
+) where {CONTENTS<:NamedTuple,BEHAVIOR}
+    if isa(contents, Unset)
+        contents = layout.contents
+    end
+    if isa(length, Unset)
+        length = layout.length
+    end
+    if isa(parameters, Unset)
+        parameters = layout.parameters
+    end
+    if isa(behavior, Unset)
+        behavior = typeof(layout).parameters[end]
+    end
+    RecordArray(contents, length, parameters = parameters, behavior = behavior)
+end
 
 function is_valid(layout::RecordArray)
     for x in values(layout.contents)
@@ -397,7 +417,7 @@ function Base.:(==)(
         return false
     end
     for k in keys(layout1.contents)   # same keys because same CONTENTS type
-        if layout1.contents[k] != layout2.contents[k]   # compare whole arrays
+        if layout1[k] != layout2[k]   # compare whole arrays
             return false
         end
     end
@@ -412,7 +432,7 @@ function Base.:(==)(
         return false
     end
     for k in keys(layout1.array.contents)   # same keys because same CONTENTS type
-        if layout1[k] != layout2[k]   # compare record items
+        if layout1[k] != layout2[k]         # compare record items
             return false
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,4 +216,60 @@ using Test
         @test !AwkwardArray.has_parameter(layout, "__list__")
     end
 
+    ### RecordArray ##########################################################
+
+    begin
+        layout = AwkwardArray.RecordArray(
+            NamedTuple{(:a, :b)}((
+                AwkwardArray.PrimitiveArray([1, 2, 3, 4, 5]),
+                AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
+            )),
+        )
+        @test AwkwardArray.is_valid(layout)
+        @test length(layout) == 5
+        @test layout[3][:a] == 3
+        @test layout[3][:b] == 3.3
+
+        @test layout == layout
+        @test layout[3] == layout[3]
+
+        tmp = 0.0
+        for x in layout
+            @test x[:b] < 6
+            tmp += x[:b]
+        end
+        @test tmp == 16.5
+    end
+
+    begin
+        layout = AwkwardArray.RecordArray(
+            NamedTuple{(:a, :b)}((
+                AwkwardArray.PrimitiveArray([1, 2, 3]),
+                AwkwardArray.ListOffsetArray(
+                    [0, 3, 3, 5],
+                    AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
+                ),
+            )),
+        )
+        @test AwkwardArray.is_valid(layout)
+        @test length(layout) == 3
+        @test layout[3][:a] == 3
+        @test layout[3][:b][1] == 4.4
+
+        @test layout == layout
+        @test layout[3] == layout[3]
+        @test layout[1][:b] == AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3])
+        @test layout[2][:b] == AwkwardArray.PrimitiveArray([])
+        @test layout[3][:b] == AwkwardArray.PrimitiveArray([4.4, 5.5])
+
+        tmp = 0.0
+        for x in layout
+            for y in x[:b]
+                @test y < 6
+                tmp += y
+            end
+        end
+        @test tmp == 16.5
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,13 +319,9 @@ using Test
         @test layout == layout
 
         @test AwkwardArray.RecordArray(
-            NamedTuple{(:a,)}((
-                AwkwardArray.PrimitiveArray([1, 2, 3]),
-            )),
+            NamedTuple{(:a,)}((AwkwardArray.PrimitiveArray([1, 2, 3]),)),
         ) == AwkwardArray.RecordArray(
-            NamedTuple{(:a,)}((
-                AwkwardArray.PrimitiveArray([1, 2, 3]),
-            )),
+            NamedTuple{(:a,)}((AwkwardArray.PrimitiveArray([1, 2, 3]),)),
         )
 
         @test layout == AwkwardArray.RecordArray(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -365,4 +365,28 @@ using Test
         )
     end
 
+    begin
+        layout_2 = AwkwardArray.RecordArray(
+            NamedTuple{(:a, :b)}((
+                AwkwardArray.PrimitiveArray([1, 2]),
+                AwkwardArray.ListOffsetArray(
+                    [0, 3, 3],
+                    AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3]),
+                ),
+            )),
+        )
+
+        layout_3 = AwkwardArray.RecordArray(
+            NamedTuple{(:a, :b)}((
+                AwkwardArray.PrimitiveArray([1, 2, 3]),
+                AwkwardArray.ListOffsetArray(
+                    [0, 3, 3, 5],
+                    AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
+                ),
+            )),
+        )
+
+        @test layout_2 == AwkwardArray.copy(layout_3, length = 2)
+    end
+
 end


### PR DESCRIPTION
RecordArray is implemented as a wrapper around Julia's NamedTuple. Whatever fast-lookup from Symbols to differently typed values NamedTuple has, RecordArray inherits it.

As usual (for Awkward Arrays), a Record _contains the RecordArray it's from_, rather than what you'd think should happen. Its equality only checks the single Record, not the whole RecordArray, though.

Also, I implemented `__getitem__`'s `int`/`str` commutativity from Python, which is `getindex`'s `Int`/`Symbol` commutativity in Julia.

```julia
layout = AwkwardArray.RecordArray(
    NamedTuple{(:a, :b)}((
        AwkwardArray.PrimitiveArray([1, 2, 3]),
        AwkwardArray.ListOffsetArray(
            [0, 3, 3, 5],
            AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
        ),
    )),
)
@test layout[3][:b][1] == 4.4
@test layout[:b][3][1] == 4.4
```

(Well, it's partial commutativity: the `:b` can't trade places with the `1` because `:a` is not a list.)

Now I'm obliged to implement `getitem` for `Int`, `UnitRange{Int}`, and `Symbol` for all Awkward node types.