### PR TITLE
fix string cancatination op. and make tests report better

### DIFF
--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -2730,7 +2730,7 @@ function _horizontal(data::Any, limit_cols::Int)
             if occursin(r"^[A-Za-z_][A-Za-z_0-9]*$", key)
                 key_str = key * ": "
             else
-                key_str = repr(key) + ": "
+                key_str = repr(key) * ": "
             end
 
             if limit_cols - (for_comma + length(key_str) + 3) >= 0
@@ -2905,7 +2905,7 @@ function _vertical(data::Union{Content,Record,Tuple}, limit_rows::Int, limit_col
             if occursin(r"^[A-Za-z_][A-Za-z_0-9]*$", key)
                 key_str = key * ": "
             else
-                key_str = repr(key) + ": "
+                key_str = repr(key) * ": "
             end
 
             (_, strs) = _horizontal(data[field], limit_cols - 2 - length(key_str))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ using AwkwardArray
 using JSON
 using Test
 
-@testset "AwkwardArray.jl" begin
     ### PrimitiveArray #######################################################
+@testset "PrimitiveArray" begin
 
     begin
         layout = AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5])
@@ -82,8 +82,10 @@ using Test
             Vector{Float32}([1.0, 2.0, 3.0, 4.0, 5.0, 3.14, 2.71]),
         )
     end
+end
 
-    ### EmptyArray ###########################################################
+### EmptyArray ###########################################################
+@testset "EmptyArray" begin
 
     begin
         layout = AwkwardArray.EmptyArray()
@@ -111,8 +113,10 @@ using Test
         append!(layout, [])
         append!(layout, Vector{Int64}([]))
     end
+end
 
     ### ListOffsetArray ######################################################
+@testset "ListOffsetArray" begin
 
     begin
         layout = AwkwardArray.ListOffsetArray(
@@ -226,8 +230,10 @@ using Test
             AwkwardArray.PrimitiveArray([1, 2, 3, 4, 5, 6, 7, 8, 9]),
         )
     end
+end
 
     ### ListArray ######################################################
+@testset "ListArray" begin
 
     begin
         layout = AwkwardArray.ListArray(
@@ -346,9 +352,11 @@ using Test
             AwkwardArray.PrimitiveArray([1, 2, 3, 4, 5, 6, 7, 8, 9]),
         )
     end
+end
 
     ### RegularArray #########################################################
 
+@testset "RegularArray" begin
     begin
         layout = AwkwardArray.RegularArray(
             AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5, 6.6]),
@@ -532,9 +540,11 @@ using Test
             3,
         )
     end
+end
 
     ### ListType with behavior = :string #####################################
 
+@testset "ListType with behavior = :string" begin
     begin
         AwkwardArray.is_valid(AwkwardArray.StringOffsetArray([0, 3, 3, 6], "onetwo"))
         AwkwardArray.is_valid(AwkwardArray.StringOffsetArray())
@@ -888,8 +898,10 @@ using Test
         )
     end
 
+end
     ### ListType with other parameters #######################################
 
+@testset "ListType with other parameters" begin
     begin
         layout = AwkwardArray.ListOffsetArray(
             [0, 3, 3, 8],
@@ -969,9 +981,11 @@ using Test
         @test AwkwardArray.get_parameter(layout, "__doc__") == "nice list"
         @test !AwkwardArray.has_parameter(layout, "__list__")
     end
+end
 
     ### RecordArray ##########################################################
 
+@testset "RecordArray" begin
     begin
         layout = AwkwardArray.RecordArray(
             NamedTuple{(:a, :b)}((
@@ -1266,9 +1280,10 @@ using Test
             )),
         )
     end
-
+end
     ### TupleArray ##########################################################
 
+@testset "TupleArray" begin
     begin
         layout = AwkwardArray.TupleArray((
             AwkwardArray.PrimitiveArray([1, 2, 3, 4, 5]),
@@ -1522,9 +1537,11 @@ using Test
             ),
         ),)
     end
+end
 
     ### IndexedArray #########################################################
 
+@testset "IndexedArray" begin
     begin
         layout = AwkwardArray.IndexedArray(
             [4, 3, 3, 0],
@@ -1689,9 +1706,11 @@ using Test
             )),
         )
     end
+end
 
     ### IndexedOptionArray ###################################################
 
+@testset "IndexedOptionArray" begin
     begin
         layout = AwkwardArray.IndexedOptionArray(
             [4, 3, 3, -1, -1, 0],
@@ -1804,9 +1823,11 @@ using Test
             ),
         )
     end
+end
 
     ### ByteMaskedArray ######################################################
 
+@testset "ByteMaskedArray" begin
     begin
         layout = AwkwardArray.ByteMaskedArray(
             [false, true, true, false, false],
@@ -1960,9 +1981,11 @@ using Test
             valid_when = true,
         )
     end
+end
 
     ### BitMaskedArray #######################################################
 
+@testset "BitMaskedArray" begin
     begin
         layout = AwkwardArray.BitMaskedArray(
             BitVector([false, true, true, false, false]),
@@ -2115,9 +2138,11 @@ using Test
             valid_when = true,
         )
     end
+end
 
     ### UnmaskedArray ########################################################
 
+@testset "UnmaskedArray" begin
     begin
         layout = AwkwardArray.UnmaskedArray(
             AwkwardArray.PrimitiveArray([1.1, 2.2, 3.3, 4.4, 5.5]),
@@ -2243,9 +2268,10 @@ using Test
             valid_when = true,
         )
     end
-
+end
     ### UnionArray ###########################################################
 
+@testset "UnionArray" begin
     begin
         layout = AwkwardArray.UnionArray(
             Vector{Int8}([0, 0, 0, 1]),
@@ -2409,9 +2435,10 @@ using Test
             ),
         )
     end
-
+end
     ### from_iter ############################################################
 
+@testset "from_iter" begin
     begin
         @test AwkwardArray.is_valid(AwkwardArray.from_iter([1, 2, 3]))
 
@@ -2487,9 +2514,11 @@ using Test
         )
 
     end
+end
 
     ### from_buffers #########################################################
 
+@testset "from_buffers" begin
     begin
         layout = AwkwardArray.from_buffers(
             """{"class": "NumpyArray", "primitive": "float64", "inner_shape": [], "parameters": {}, "form_key": "node0"}""",
@@ -3127,5 +3156,4 @@ using Test
             "node5-data" => Vector{UInt8}(b"five"),
         )
     end
-
 end   # @testset "AwkwardArray.jl"


### PR DESCRIPTION
this time JET.jl finds something real


```julia
     Testing Running tests...
Test Summary:  | Pass  Total  Time
PrimitiveArray |   31     31  0.1s
Test Summary: | Pass  Total  Time
EmptyArray    |    8      8  0.0s
Test Summary:   | Pass  Total  Time
ListOffsetArray |   26     26  0.1s
Test Summary: | Pass  Total  Time
ListArray     |   26     26  0.1s
Test Summary: | Pass  Total  Time
RegularArray  |   49     49  0.5s
Test Summary:                    | Pass  Total  Time
ListType with behavior = :string |   59     59  1.0s
Test Summary:                  | Pass  Total  Time
ListType with other parameters |   12     12  0.1s
Test Summary: | Pass  Total  Time
RecordArray   |   57     57  0.5s
Test Summary: | Pass  Total  Time
TupleArray    |   57     57  0.3s
Test Summary: | Pass  Total  Time
IndexedArray  |   56     56  0.1s
Test Summary:      | Pass  Total  Time
IndexedOptionArray |   31     31  0.1s
Test Summary:   | Pass  Total  Time
ByteMaskedArray |   44     44  0.1s
Test Summary:  | Pass  Total  Time
BitMaskedArray |   44     44  0.1s
Test Summary: | Pass  Total  Time
UnmaskedArray |   42     42  0.0s
Test Summary: | Pass  Total  Time
UnionArray    |   31     31  0.7s
Test Summary: | Pass  Total  Time
from_iter     |   17     17  2.9s
Test Summary: | Pass  Total  Time
from_buffers  |  112    112  4.9s
     Testing AwkwardArray tests passed
```

this makes running tests locally more responsive and also maybe more informative

