### PR TITLE
add `from_table` that uses Tables.jl interface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.8'
           - '1.9'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0-DEV"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 julia = "1.8"

--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -1,7 +1,7 @@
 module AwkwardArray
 
 import JSON
-using Tables
+import Tables
 
 ### Index ################################################################
 

--- a/src/AwkwardArray.jl
+++ b/src/AwkwardArray.jl
@@ -1,6 +1,7 @@
 module AwkwardArray
 
 import JSON
+using Tables
 
 ### Index ################################################################
 
@@ -2348,6 +2349,19 @@ function layout_for(ItemType)
             error("cannot produce an AwkwardArray layout for $ItemType")
         end
     end
+end
+
+function from_table(input)
+    sch = Tables.schema(input)
+    NT = NamedTuple{sch.names, Base.Tuple{sch.types...}}
+    AwkwardType = layout_for(NT)
+    out = AwkwardType()
+
+    for row in Tables.rows(input)
+        push!(out, NT(row))
+    end
+
+    return out
 end
 
 function from_iter(input)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,21 @@
+Tables.istable(::Type{RecordArray}) = true
+
+Tables.columnaccess(::Type{RecordArray}) = true
+Tables.columns(x::RecordArray) = x.contents
+Tables.columnnames(x::RecordArray) = keys(x.contents)
+
+Tables.schema(x::RecordArray) = Tables.Schema(Tables.columnnames(x), eltype.(values(Tables.columns(x))))
+
+function from_table(input)
+    sch = Tables.schema(input)
+    NT = NamedTuple{sch.names, Base.Tuple{sch.types...}}
+    AwkwardType = layout_for(NT)
+    out = AwkwardType()
+
+    for row in Tables.rows(input)
+        push!(out, NT(row))
+    end
+
+    return out
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3163,7 +3163,7 @@ end
         awt = AwkwardArray.from_table(df)
         @test Tables.schema(df) == Tables.schema(awt)
 
-        @test df.x = AwkwardArray.to_vector(awt[:x])
-        @test df.y = AwkwardArray.to_vector(awt[:y])
+        @test df.x == AwkwardArray.to_vector(awt[:x])
+        @test df.y == AwkwardArray.to_vector(awt[:y])
     end
 end   # @testset "AwkwardArray.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using AwkwardArray
 using JSON
 using Test
+using Tables
 
     ### PrimitiveArray #######################################################
 @testset "PrimitiveArray" begin
@@ -3155,5 +3156,14 @@ end
             ),
             "node5-data" => Vector{UInt8}(b"five"),
         )
+    end
+
+    @testset "Tables.jl intergration" begin
+        df = (; x = [[1], [2], [1,2,3]], y = [4.0, 5, 6])
+        awt = AwkwardArray.from_table(df)
+        @test Tables.schema(df) == Tables.schema(awt)
+
+        @test df.x = AwkwardArray.to_vector(awt[:x])
+        @test df.y = AwkwardArray.to_vector(awt[:y])
     end
 end   # @testset "AwkwardArray.jl"


### PR DESCRIPTION
```julia
julia> using UnROOT, AwkwardArray

julia> const t = LazyTree(UnROOT.samplefile("NanoAODv5_sample.root"), "Events", r"Muon_(pt|eta|phi)$");

# after warming up

julia> @time AwkwardArray.from_table(t);
  0.000460 seconds (2.22 k allocations: 279.617 KiB)

julia> @time NamedTuple.(t);
  0.000529 seconds (9.01 k allocations: 820.656 KiB)

julia> @time AwkwardArray.from_iter(NamedTuple.(t));
  0.001461 seconds (10.19 k allocations: 1.027 MiB)
```

I find it very interesting that `from_table` allocates less than just making a `Vector{<:NamedTuple}`, somehow!

